### PR TITLE
Adding --no-perms to stop triggering deltas.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -124,7 +124,7 @@ NEW_CONTAINER() {
 	local TDOMAIN="${2}"
 	local TPORT="${3}"
 	POST_BUILD_JSON_BUSY "Starting ${TDOMAIN}"
-	docker run --restart=always -p "${TPORT}:8080" -d "${TKEY}"
+	docker run --restart=unless-stopped -p "${TPORT}:8080" -d "${TKEY}"
 	POST_BUILD_JSON_BUSY "Adding ${TDOMAIN} web server config"
 	NEW_VIRTUAL_HOST "${NGINX_CONFD_PATH}/${TDOMAIN}.conf" "${TDOMAIN}" "${TKEY}" "${TPORT}"
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -108,9 +108,7 @@ KILL_UNNEEDED_CONTAINERS() {
 	RUNNING_CONTAINERS="$(docker ps)"
 	declare IDS_TO_IMAGES
 	IDS_TO_IMAGES=$(echo "${RUNNING_CONTAINERS}" | awk '{print $1, $2}')
-	while read TKEY TDOMAIN TPORT; do
-		PATTERN="${PATTERN} -e ${TKEY}"
-	done < "${APPS_KEYS_TXT_PATH}"
+	while read TKEY TDOMAIN TPORT; do PATTERN="${PATTERN} -e ${TKEY}"; done < "${APPS_KEYS_TXT_PATH}"
 	declare CONTAINERS
 	CONTAINERS=$(echo "${IDS_TO_IMAGES}" | grep ${PATTERN} | cat)
 	declare CONTAINER_IDS

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -148,7 +148,7 @@ docker kill $(docker ps -q) || true
 
 while read TKEY TDOMAIN TPORT; do
 	POST_BUILD_JSON_BUSY "Downloading application ${TDOMAIN}"
-	echo "diff size: $(rsync -aPzri --progress "node@${HUB_GODDARD_UNICORE}:${GODDARD_APPS_BASE_PATH}/${TKEY}/" "${GODDARD_APPS_BASE_PATH}/${TKEY}" | wc -l)"
+	echo "diff size: $(rsync -aPzri --no-perms --progress "node@${HUB_GODDARD_UNICORE}:${GODDARD_APPS_BASE_PATH}/${TKEY}/" "${GODDARD_APPS_BASE_PATH}/${TKEY}" | wc -l)"
 	POST_BUILD_JSON_BUSY "Building ${TDOMAIN}"
 	cd "${GODDARD_APPS_BASE_PATH}/${TKEY}" && docker build --tag="${TKEY}" --rm=true "."
 	POST_BUILD_JSON_BUSY "Stopping ${TKEY}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,7 +100,7 @@ POST_BUILD_JSON_DONE() {
 	POST_TO_SERVER
 }
 
-KILL_UNNEEDED_CONTAINERS() {
+STOP_UNNEEDED_CONTAINERS() {
 	# perform a reverse grep with multiple patterns to determine
 	# which containers should NOT be running based on app keys text file
 	local PATTERN="-v"
@@ -116,7 +116,7 @@ KILL_UNNEEDED_CONTAINERS() {
 	# container_ids is going to contain the string "CONTAINER"
 	# so running docker kill will inevitably produce some
 	# alarming output, but it wont break anything...
-	docker kill ${CONTAINER_IDS} || true
+	docker stop --time=30 ${CONTAINER_IDS} || true
 }
 
 NEW_CONTAINER() {
@@ -171,7 +171,7 @@ POST_BUILD_JSON_BUSY "Downloaded app list for node..."
 jq -r '.[]  | "\(.key) \(.domain) \(.port)"' < "${APPS_JSON_PATH}" > "${APPS_KEYS_TXT_PATH}"
 rm "${NGINX_CONFD_PATH}/*.conf" || true
 
-KILL_UNNEEDED_CONTAINERS
+STOP_UNNEEDED_CONTAINERS
 
 while read TKEY TDOMAIN TPORT; do
 	


### PR DESCRIPTION
This should stop Nodes from detecting a delta when rsyncing down apps.
For review in the morning by @skibz  and @Johanndutoit . We can rolled this out automagically with NodeUpdater.
