### PR TITLE
Rsync status for captive portal

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -22,8 +22,8 @@ curl \
 du -ach /var/goddard/media > /var/goddard/media_du_human.log
 du -ac /var/goddard/media > /var/goddard/media_du_machine.log
 
-# remove the old rsync log file if it exists
-rm /var/goddard/media_rsync.log || true
+# mangle the original log
+echo "" > /var/goddard/media_rsync.log
 
 # execute script to pull down new media using Rsync
 rsync \ 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -40,7 +40,7 @@ du -ac /var/goddard/media > /var/goddard/media_du_machine.log
 
 # done
 echo "{
-  \"build\":\"busy\",
+  \"build\":\"done\",
   \"process\":\"Media cache finished downloading\",
   \"timestamp\":\"$(date +%s)\"
 }" > /var/goddard/build.json

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -4,19 +4,46 @@
 echo "Starting to pull down new media"
 
 # done
-echo "{\"build\":\"busy\",\"process\":\"Starting to download media cache\",\"timestamp\":\"$( date +%s )\"}"  > /var/goddard/build.json
+echo "{
+  \"build\":\"busy\",
+  \"process\":\"Starting to download media cache\",
+  \"timestamp\":\"$(date +%s)\"
+}" > /var/goddard/build.json
 
 # post to server
-curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') --header "Content-Type:application/json"
+curl \
+  --silent \
+  -X POST \
+  -d @/var/goddard/build.json \
+  http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') \
+  --header "Content-Type:application/json"
+
+# remove the old rsync log file if it exists
+rm /var/goddard/media_sync.log || true
 
 # execute script to pull down new media using Rsync
-rsync -aPzri --delete --progress node@hub.goddard.unicore.io:/var/goddard/media/ /var/goddard/media
+rsync \ 
+  -aPzri \
+  --delete \
+  --progress \
+  --log-file=/var/goddard/media_sync.log \
+  node@hub.goddard.unicore.io:/var/goddard/media/ \
+  /var/goddard/media
 
 # done
-echo "{\"build\":\"busy\",\"process\":\"Media cache finished downloading\",\"timestamp\":\"$( date +%s )\"}"  > /var/goddard/build.json
+echo "{
+  \"build\":\"busy\",
+  \"process\":\"Media cache finished downloading\",
+  \"timestamp\":\"$(date +%s)\"
+}" > /var/goddard/build.json
 
 # post to server
-curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') --header "Content-Type:application/json"
+curl \
+  --silent \
+  -X POST \
+  -d @/var/goddard/build.json \
+  http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') \
+  --header "Content-Type:application/json"
 
 # debug
 echo "Done pulling media with script"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -18,6 +18,9 @@ curl \
   http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') \
   --header "Content-Type:application/json"
 
+# refresh the folder sizes BEFORE the rsync
+du --max-depth=5 -c -h /var/goddard/media > /var/goddard/media_sizes.log
+
 # remove the old rsync log file if it exists
 rm /var/goddard/media_sync.log || true
 
@@ -29,6 +32,9 @@ rsync \
   --log-file=/var/goddard/media_sync.log \
   node@hub.goddard.unicore.io:/var/goddard/media/ \
   /var/goddard/media
+
+# refresh the folder sizes AFTER the rsync
+du --max-depth=5 -c -h /var/goddard/media > /var/goddard/media_sizes.log
 
 # done
 echo "{

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -18,23 +18,25 @@ curl \
   http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') \
   --header "Content-Type:application/json"
 
-# refresh the folder sizes BEFORE the rsync
-du --max-depth=5 -c -h /var/goddard/media > /var/goddard/media_sizes.log
+# refresh the folder sizes before the rsync
+du -ach /var/goddard/media > /var/goddard/media_du_human.log
+du -ac /var/goddard/media > /var/goddard/media_du_machine.log
 
 # remove the old rsync log file if it exists
-rm /var/goddard/media_sync.log || true
+rm /var/goddard/media_rsync.log || true
 
 # execute script to pull down new media using Rsync
 rsync \ 
   -aPzri \
   --delete \
   --progress \
-  --log-file=/var/goddard/media_sync.log \
+  --log-file=/var/goddard/media_rsync.log \
   node@hub.goddard.unicore.io:/var/goddard/media/ \
   /var/goddard/media
 
-# refresh the folder sizes AFTER the rsync
-du --max-depth=5 -c -h /var/goddard/media > /var/goddard/media_sizes.log
+# refresh the folder sizes after the rsync
+du -ach /var/goddard/media > /var/goddard/media_du_human.log
+du -ac /var/goddard/media > /var/goddard/media_du_machine.log
 
 # done
 echo "{


### PR DESCRIPTION
creates three files that are used by the captive portal: two files with `du` output and another with `rsync` log output.
