### PR TITLE
correct values for build.json

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -13,7 +13,11 @@ curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/
 rsync -aPzri --delete --progress node@hub.goddard.unicore.io:/var/goddard/media/ /var/goddard/media
 
 # done
-echo "{\"build\":\"busy\",\"process\":\"Media cache finished downloading\",\"timestamp\":\"$( date +%s )\"}"  > /var/goddard/build.json
+echo "{
+  \"build\":\"done\",
+  \"process\":\"Media cache finished downloading\",
+  \"timestamp\":\"$( date +%s )\"
+}"  > /var/goddard/build.json
 
 # post to server
 curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') --header "Content-Type:application/json"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,7 +4,11 @@
 echo "Updating the agent"
 
 # done
-echo "{\"build\":\"busy\",\"process\":\"Self updating the agent\",\"timestamp\":\"$( date +%s )\"}"  > /var/goddard/build.json
+echo "{
+  \"build\":\"busy\",
+  \"process\":\"Self updating the agent\",
+  \"timestamp\":\"$( date +%s )\"
+}"  > /var/goddard/build.json
 
 # post to server
 curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') --header "Content-Type:application/json"
@@ -13,7 +17,11 @@ curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/
 rsync -aPzri --progress node@hub.goddard.unicore.io:/var/goddard/agent/ /var/goddard/agent
 
 # done
-echo "{\"build\":\"busy\",\"process\":\"Node Agent was updated without problems\",\"timestamp\":\"$( date +%s )\"}"  > /var/goddard/build.json
+echo "{
+  \"build\":\"done\",
+  \"process\":\"Node Agent was updated without problems\",
+  \"timestamp\":\"$( date +%s )\"
+}"  > /var/goddard/build.json
 
 # post to server
 curl --silent -X POST -d @/var/goddard/build.json http://hub.goddard.unicore.io/report.json?uid=$(cat /var/goddard/node.json | jq -r '.uid') --header "Content-Type:application/json"


### PR DESCRIPTION
some shell scripts end up setting the build.json file to a "busy" state after the script has finished, which causes the captive portal status page to report incorrect data.
