### PR TITLE
Configures SQUID as a transparent proxy that will handle the whitelisting

### DIFF
--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -49,9 +49,6 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   # pull out the password for the 750
   ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.NEW_RB750_PASSWORD")
 
-  # debug
-  echo "Found Password: $ROUTER_PASSWORD" 
-
   # run the commands to migrate changes over to mikrotik
   RUN_COMMAND "/ip hotspot user profile set 0 transparent-proxy=yes"
   RUN_COMMAND "/ip proxy set enabled=yes"

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -46,17 +46,13 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   # restart the squid instance to load new config
   service squid3 restart
 
-  # pull out the password for the 750
-  ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.NEW_RB750_PASSWORD")
-
   # run the commands to migrate changes over to mikrotik
-  RUN_COMMAND "/ip hotspot user profile set 0 transparent-proxy=yes"
-  RUN_COMMAND "/ip proxy set enabled=yes"
-  RUN_COMMAND "/ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128"
+  RUN_COMMAND "/ip dhcp-server option add name=wpad code=252 value="'http://wpad.mamawifi.com:80/wpad.dat'""
+  RUN_COMMAND "/ip dhcp-server network set 1 dhcp-option=wpad"
   RUN_COMMAND "/ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]"
-  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.5 server=hotspot1"
-  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.10 server=hotspot1"
-  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.50 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.5 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.10 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.50 server=hotspot1"
   RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=* server=hotspot1"
 
   # write our log file

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -11,7 +11,7 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   sudo apt-get update
 
   # install squid 
-  sudo apt-get install squid -y
+  sudo apt-get install squid sshpass -y
 
   # update the config
   cp templates/squid.conf /etc/squid3/squid.conf
@@ -30,6 +30,24 @@ if [ ! -f "/var/goddard/proxy.lock" ];
 
   # restart the squid instance to load new config
   service squid3 restart
+
+  # pull out the password for the 750
+  ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.NEW_RB750_PASSWORD")
+
+  # debug
+  echo "Found Password: $ROUTER_PASSWORD" 
+
+  # run the commands to migrate changes over to mikrotik
+  sshpass -p "$ROUTER_PASSWORD" ssh admin@192.168.88.5 "$(which bash) -s" << EOF
+      /ip hotspot user profile set 0 transparent-proxy=yes
+      /ip proxy set enabled=yes
+      /ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128
+      /ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]
+      /ip hotspot walled-garden add action=deny dst-host=192.168.88.5 server=hotspot1
+      /ip hotspot walled-garden add action=deny dst-host=192.168.88.10 server=hotspot1
+      /ip hotspot walled-garden add action=deny dst-host=192.168.88.50 server=hotspot1
+      /ip hotspot walled-garden add action=allow dst-host=* server=hotspot1
+  EOF
 
   # write our log file
   date > /var/goddard/proxy.lock

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -12,9 +12,6 @@ RUN_COMMAND() {
   ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.RB750_PASSWORD")
   NEW_ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.NEW_RB750_PASSWORD")
 
-  # debug
-  echo "Found Password: $ROUTER_PASSWORD" 
-
   # run it with both password to work with all the nodes
   echo "${COMMAND}" | sshpass -p "$ROUTER_PASSWORD" ssh admin@192.168.88.5 || true
   echo "${COMMAND}" | sshpass -p "$NEW_ROUTER_PASSWORD" ssh admin@192.168.88.5 || true

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -3,6 +3,24 @@
 # listen for any issues
 set -e
 
+RUN_COMMAND() {
+
+  # get the local command var we can use
+  local COMMAND="${1}"
+  
+  # pull out the password for the 750
+  ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.RB750_PASSWORD")
+  NEW_ROUTER_PASSWORD=$(python -c "import imp; localsettings=imp.load_source('localsettings', '/var/goddard/node_updater/local_settings.py'); print localsettings.NEW_RB750_PASSWORD")
+
+  # debug
+  echo "Found Password: $ROUTER_PASSWORD" 
+
+  # run it with both password to work with all the nodes
+  echo "${COMMAND}" | sshpass -p "$ROUTER_PASSWORD" ssh admin@192.168.88.5 || true
+  echo "${COMMAND}" | sshpass -p "$NEW_ROUTER_PASSWORD" ssh admin@192.168.88.5 || true
+
+}
+
 # don't run if already setup
 if [ ! -f "/var/goddard/proxy.lock" ]; 
   then
@@ -38,16 +56,14 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   echo "Found Password: $ROUTER_PASSWORD" 
 
   # run the commands to migrate changes over to mikrotik
-  sshpass -p "$ROUTER_PASSWORD" ssh admin@192.168.88.5 "$(which bash) -s" << EOF
-      /ip hotspot user profile set 0 transparent-proxy=yes
-      /ip proxy set enabled=yes
-      /ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128
-      /ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]
-      /ip hotspot walled-garden add action=deny dst-host=192.168.88.5 server=hotspot1
-      /ip hotspot walled-garden add action=deny dst-host=192.168.88.10 server=hotspot1
-      /ip hotspot walled-garden add action=deny dst-host=192.168.88.50 server=hotspot1
-      /ip hotspot walled-garden add action=allow dst-host=* server=hotspot1
-  EOF
+  RUN_COMMAND "/ip hotspot user profile set 0 transparent-proxy=yes"
+  RUN_COMMAND "/ip proxy set enabled=yes"
+  RUN_COMMAND "/ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128"
+  RUN_COMMAND "/ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.5 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.10 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.50 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=* server=hotspot1"
 
   # write our log file
   date > /var/goddard/proxy.lock

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -75,6 +75,12 @@ sudo cat <<-EOF > /var/goddard/wpad.dat
   }
 EOF
 
+# update whitelist
+python /var/goddard/agent/templates/acl.py > /var/goddard/whitelist
+
+# verify that the config is correct before restarting
+/usr/sbin/squid3 -k reconfigure
+
 # reload nginx
 service nginx reload || true
 

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -3,23 +3,35 @@
 # listen for any issues
 set -e
 
-# update apt first
-sudo apt-get update
+# don't run if already setup
+if [ ! -f "/var/goddard/proxy.lock" ]; 
+  then
 
-# install squid 
-sudo apt-get install squid -y
+  # update apt first
+  sudo apt-get update
 
-# update the config
-cp ../templates/squid.conf /etc/squid3/squid.conf
+  # install squid 
+  sudo apt-get install squid -y
 
-# create the error folder
-mkdir -p /etc/squid3/errors/
+  # update the config
+  cp ../templates/squid.conf /etc/squid3/squid.conf
 
-# copy over our error page
-cp ../templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
+  # create the error folder
+  mkdir -p /etc/squid3/errors/
 
-# restart the squid instance to load new config
-service squid3 restart
+  # copy over our error page
+  cp ../templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
+
+  # verify that the config is correct before restarting
+  /usr/sbin/squid3 -k parse
+
+  # restart the squid instance to load new config
+  service squid3 restart
+
+  # write our log file
+  date > /var/goddard/proxy.lock
+
+fi
 
 ####
 # TODO update mikrotik

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -29,7 +29,7 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   sudo apt-get install squid sshpass -y
 
   # update the config
-  cp templates/squid.conf /etc/squid3/squid.conf
+  cp /var/goddard/agent/templates/squid.conf /etc/squid3/squid.conf
 
   # create the error folder
   mkdir -p /etc/squid3/errors/

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -35,10 +35,10 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   mkdir -p /etc/squid3/errors/
 
   # copy over the acl script
-  cp templates/acl.py /var/goddard/acl.py
+  cp /var/goddard/agent/templates/acl.py /var/goddard/acl.py
 
   # copy over our error page
-  cp templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
+  cp /var/goddard/agent/templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
 
   # verify that the config is correct before restarting
   /usr/sbin/squid3 -k parse

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -25,7 +25,7 @@ if [ ! -f "/var/goddard/proxy.lock" ];
     "/var/cache/apt/archives/"
 
   # install squid 
-  sudo apt-get install -y squid sshpass
+  sudo apt-get install -y --force-yes squid sshpass
 
   # update the config
   cp /var/goddard/agent/templates/squid.conf /etc/squid3/squid.conf

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -51,10 +51,10 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   RUN_COMMAND "/ip dhcp-server network set 0 dhcp-option=wpad"
   RUN_COMMAND "/ip dhcp-server network set 1 dhcp-option=wpad"
   RUN_COMMAND "/ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]"
-  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.5 server=hotspot1"
-  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.10 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.5 server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=192.168.88.10 server=hotspot1"
   RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=192.168.88.50 server=hotspot1"
-  RUN_COMMAND "/ip hotspot walled-garden add action=allow dst-host=* server=hotspot1"
+  RUN_COMMAND "/ip hotspot walled-garden add action=deny dst-host=* server=hotspot1"
 
   # write our log file
   date > /var/goddard/proxy.lock

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+# listen for any issues
+set -e
+
+# update apt first
+sudo apt-get update
+
+# install squid 
+sudo apt-get install squid -y
+
+# update the config
+cp ../templates/squid.conf /etc/squid3/squid.conf
+
+# create the error folder
+mkdir -p /etc/squid3/errors/
+
+# copy over our error page
+cp ../templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
+
+# restart the squid instance to load new config
+service squid3 restart
+
+####
+# TODO update mikrotik
+# Run the following:
+# /ip hotspot user profile set 0 transparent-proxy=yes
+# /ip proxy set enabled=yes
+# /ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128
+###

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -22,13 +22,7 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   # download the debs from the server
   rsync -azri --no-perms \
     "node@hub.goddard.unicore.io:/var/goddard/debs/" \
-    "/var/goddard/debs"
-
-  # install our missing debs
-  dpkg -i /var/goddard/debs/*.deb
-
-  # install squid 
-  sudo apt-get install -f
+    "/var/cache/apt/archives/"
 
   # install squid 
   sudo apt-get install -y squid sshpass

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -14,13 +14,13 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   sudo apt-get install squid -y
 
   # update the config
-  cp ../templates/squid.conf /etc/squid3/squid.conf
+  cp templates/squid.conf /etc/squid3/squid.conf
 
   # create the error folder
   mkdir -p /etc/squid3/errors/
 
   # copy over our error page
-  cp ../templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
+  cp templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
 
   # verify that the config is correct before restarting
   /usr/sbin/squid3 -k parse
@@ -39,4 +39,6 @@ fi
 # /ip hotspot user profile set 0 transparent-proxy=yes
 # /ip proxy set enabled=yes
 # /ip proxy set parent-proxy=192.168.88.50 set parent-proxy-port=3128
+# remove the whitelist
+# add the new walled garden entries
 ###

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -19,6 +19,9 @@ RUN_COMMAND() {
 if [ ! -f "/var/goddard/proxy.lock" ]; 
   then
 
+  # just in case the folder does not exist
+  mkdir -p /var/cache/apt/archives/
+
   # download the debs from the server
   rsync -azri --no-perms \
     "node@hub.goddard.unicore.io:/var/goddard/debs/" \

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -40,6 +40,9 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   # verify that the config is correct before restarting
   /usr/sbin/squid3 -k parse
 
+  # create the file
+  touch /var/goddard/whitelist
+
   # restart the squid instance to load new config
   service squid3 restart
 

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -19,6 +19,9 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   # create the error folder
   mkdir -p /etc/squid3/errors/
 
+  # copy over the acl script
+  cp templates/acl.py /var/goddard/acl.py
+
   # copy over our error page
   cp templates/error.accessdenied.html /etc/squid3/errors/ERR_ACCESS_DENIED
 

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -47,7 +47,7 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   ssh-keyscan 192.168.88.5 >> ~/.ssh/known_hosts
 
   # run the commands to migrate changes over to mikrotik
-  RUN_COMMAND "/ip dhcp-server option add name=wpad code=252 value="'http://wpad.mamawifi.com:80/wpad.dat'""
+  RUN_COMMAND "/ip dhcp-server option add name=wpad code=252 value=\"'http://wpad.mamawifi.com:80/wpad.dat'\""
   RUN_COMMAND "/ip dhcp-server network set 0 dhcp-option=wpad"
   RUN_COMMAND "/ip dhcp-server network set 1 dhcp-option=wpad"
   RUN_COMMAND "/ip hotspot walled-garden remove numbers=[/ip hotspot walled-garden find ]"
@@ -60,6 +60,20 @@ if [ ! -f "/var/goddard/proxy.lock" ];
   date > /var/goddard/proxy.lock
 
 fi
+
+# write out the wpad config file
+sudo cat <<-EOF > /var/goddard/wpad.dat
+  function FindProxyForURL(url, host)
+  {
+  if (isInNet(host, "192.168.88.0", "255.255.255.0"))
+  return "DIRECT";
+  else
+  return "PROXY 192.168.88.50:3128";
+  }
+EOF
+
+# reload nginx
+service nginx reload || true
 
 ####
 # TODO update mikrotik

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -19,11 +19,19 @@ RUN_COMMAND() {
 if [ ! -f "/var/goddard/proxy.lock" ]; 
   then
 
-  # update apt first
-  sudo apt-get update
+  # download the debs from the server
+  rsync -azri --no-perms \
+    "node@hub.goddard.unicore.io:/var/goddard/debs/" \
+    "/var/goddard/debs"
+
+  # install our missing debs
+  dpkg -i /var/goddard/debs/*.deb
 
   # install squid 
-  sudo apt-get install squid sshpass -y
+  sudo apt-get install -f
+
+  # install squid 
+  sudo apt-get install -y squid sshpass
 
   # update the config
   cp /var/goddard/agent/templates/squid.conf /etc/squid3/squid.conf

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -266,4 +266,8 @@ POST_BUILD_JSON_DONE
 
 UNLINK_SETUP_LOCK
 
+# ensure proxy is runnable
+chmod a+x scripts/proxy.sh	
+./scripts/proxy.sh
+
 exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -267,7 +267,6 @@ POST_BUILD_JSON_DONE
 UNLINK_SETUP_LOCK
 
 # ensure proxy is runnable
-chmod a+x /var/goddard/agent/scripts/proxy.sh	
-/var/goddard/agent/scripts/proxy.sh
+sh /var/goddard/agent/scripts/proxy.sh
 
 exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -260,6 +260,26 @@ REMOVE_STALE_CONTAINERS
 
 REMOVE_UNNEEDED_VIRTUAL_HOSTS
 
+# write out WPAD config
+sudo cat <<-EOF > /etc/nginx/conf.d/wpad.mamawifi.com.conf
+		server {
+		listen              80;
+		server_name         wpad.goddard.com wpad.mamawifi.com;
+		root                /var/goddard;
+		access_log          /var/log/nginx/wpad.mamawifi.com.log;
+		}
+	EOF
+
+sudo cat <<-EOF > /var/goddard/wpad.dat
+		function FindProxyForURL(url, host)
+		{
+		if (isInNet(host, "192.168.88.0", "255.255.255.0"))
+		return "DIRECT";
+		else
+		return "PROXY 192.168.88.50:3128";
+		}
+	EOF
+
 service nginx reload || true
 
 POST_BUILD_JSON_DONE

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,6 +14,9 @@ APPS_KEYS_TXT_PATH="${GODDARD_BASE_PATH}/apps.keys.txt"
 NGINX_CONFD_PATH="/etc/nginx/conf.d"
 HUB_GODDARD_UNICORE="hub.goddard.unicore.io"
 
+# ensure proxy is runnable
+sh /var/goddard/agent/scripts/proxy.sh
+
 last_ret_code=$1
 
 NEW_VIRTUAL_HOST() {
@@ -260,33 +263,10 @@ REMOVE_STALE_CONTAINERS
 
 REMOVE_UNNEEDED_VIRTUAL_HOSTS
 
-# write out WPAD config
-sudo cat <<-EOF > /etc/nginx/conf.d/wpad.mamawifi.com.conf
-		server {
-		listen              80;
-		server_name         wpad.goddard.com wpad.mamawifi.com;
-		root                /var/goddard;
-		access_log          /var/log/nginx/wpad.mamawifi.com.log;
-		}
-	EOF
-
-sudo cat <<-EOF > /var/goddard/wpad.dat
-		function FindProxyForURL(url, host)
-		{
-		if (isInNet(host, "192.168.88.0", "255.255.255.0"))
-		return "DIRECT";
-		else
-		return "PROXY 192.168.88.50:3128";
-		}
-	EOF
-
 service nginx reload || true
 
 POST_BUILD_JSON_DONE
 
 UNLINK_SETUP_LOCK
-
-# ensure proxy is runnable
-sh /var/goddard/agent/scripts/proxy.sh
 
 exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -267,7 +267,7 @@ POST_BUILD_JSON_DONE
 UNLINK_SETUP_LOCK
 
 # ensure proxy is runnable
-chmod a+x scripts/proxy.sh	
-./scripts/proxy.sh
+chmod a+x /var/goddard/agent/scripts/proxy.sh	
+/var/goddard/agent/scripts/proxy.sh
 
 exit 0

--- a/templates/acl.py
+++ b/templates/acl.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+import io
+import sys
+
+###
+# cached version of the website
+# so we can avoid loading it everytime ...
+###
+cached_whitelist=[]
+
+# keep looping while waiting for input from Squid
+while True:
+  # read in the information from squid
+  line = sys.stdin.readline().strip()
+
+
+  if line:
+    # debugging
+    f = open('/var/goddard/acl.txt', 'a')
+    f.write( str(line) + '\n' )
+    f.close()
+
+    # get the whitelisted domains
+    if len(cached_whitelist) == 0:
+
+      # load in the whitelist
+      cached_whitelist = [ 'opera', 'io.co.za', 'reddit.com', 'captive.apple.com', 'clientconnectivitycheck.android.com', 'clients3.google.com' ]
+
+    # output to send out to Squid
+    filter_output_str = 'ERR'
+
+    # check if in the input
+    for whitelist_str in cached_whitelist:
+      if whitelist_str in str( line ).lower():
+        filter_output_str = 'OK'
+        break
+
+    # handle the output
+    print filter_output_str
+    sys.stdout.flush()
+  else:
+    print "ERR"
+    sys.stdout.flush()

--- a/templates/acl.py
+++ b/templates/acl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import io
 import sys
+import json
 
 ###
 # cached version of the website
@@ -15,16 +16,59 @@ while True:
 
 
   if line:
+
+    """
     # debugging
     f = open('/var/goddard/acl.txt', 'a')
     f.write( str(line) + '\n' )
     f.close()
+    """
 
     # get the whitelisted domains
     if len(cached_whitelist) == 0:
 
-      # load in the whitelist
-      cached_whitelist = [ 'opera', 'io.co.za', 'reddit.com', 'captive.apple.com', 'clientconnectivitycheck.android.com', 'clients3.google.com' ]
+      # awesome so read in the whitelist with a few of our own defaults as well
+      cached_whitelist = [
+
+        'captive.apple.com', 
+        'clientconnectivitycheck.android.com', 
+        'clients3.google.com'
+
+      ]
+
+      # get the node info
+      node_info_obj = None 
+
+      # try to parse it out
+      try:
+
+        # try to read as a file
+        f = open('/var/goddard/node.json', 'r')
+
+        # get the contents
+        file_content_str = str(f.read())
+
+        # parse as JSON object
+        node_info_obj = json.loads( file_content_str )
+
+        # close the handler
+        f.close()
+
+      except Exception, e: pass
+
+      # if we found the node object
+      if node_info_obj == None:
+
+        # set to empty again to retry the next time
+        cached_whitelist = []
+
+      else:
+
+        # add all the domains
+        for whitelist_obj in node_info_obj['whitelist']:
+
+          # add the domain
+          cached_whitelist.append( whitelist_obj['domain'] )
 
     # output to send out to Squid
     filter_output_str = 'ERR'

--- a/templates/acl.py
+++ b/templates/acl.py
@@ -32,7 +32,9 @@ while True:
 
         'captive.apple.com', 
         'clientconnectivitycheck.android.com', 
-        'clients3.google.com'
+        'clients3.google.com',
+        'operamini.com',
+        'opera-mini.com'
 
       ]
 

--- a/templates/error.accessdenied.html
+++ b/templates/error.accessdenied.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+    <title>Site not allowed</title>
+</head>
+<body id="%c">
+  <p>The site <strong>%U</strong> is blocked, redirecting to <a href="http://mamawifi.com">mamawifi.com</a> in 2 seconds</p>.
+
+  <script type="text/javascript">
+    document.location = 'http://mamawifi.com';
+  </script>
+</body>
+</html>

--- a/templates/squid.conf
+++ b/templates/squid.conf
@@ -5,6 +5,8 @@ http_port 3128
 # https_port 3130 transparent
 strip_query_terms off
 
+# debug_options ALL,1 28,4 29,6 82,6
+
 # access_log /var/log/nginx/squid.log squid
 
 acl all src all
@@ -19,31 +21,18 @@ acl SSL_ports port 443        # https
 # acl SSL_ports port 563        # snews
 # acl SSL_ports port 873        # rsync
 acl Safe_ports port 80        # http
-acl Safe_ports port 3120  # proxy
-acl Safe_ports port 3128        # ftp
 acl Safe_ports port 443        # https
 acl purge method PURGE
 acl CONNECT method CONNECT
 
-external_acl_type checkwhitelist children=20 %METHOD %PROTO %DST %PATH /var/goddard/acl.py
-
-acl opera_match url_regex "opera"
-acl urlmatch url_regex "/var/goddard/urls"
-# acl whitelist dstdomain "/var/goddard/whitelist"
-acl whitelist external checkwhitelist
-
+acl whitelist dstdomain "/var/goddard/whitelist"
 # Deny requests to unknown ports
-http_access deny !Safe_ports
-# http_access allow opera_match
-http_access deny !whitelist
-# http_access allow urlmatch
+http_access allow whitelist
 
-# Deny CONNECT to other than SSL ports
-http_access deny CONNECT !SSL_ports
-
-http_access allow all
 http_access deny to_localhost
-http_access allow localnet
+# http_access allow localnet
+
+# http_access allow Safe_ports
 
 # And deny all other access to this proxy
 http_access deny all

--- a/templates/squid.conf
+++ b/templates/squid.conf
@@ -1,0 +1,115 @@
+# Squid normally listens to port 3128
+# http_port 3120
+http_port 3128
+# http_port 3129 intercept
+# https_port 3130 transparent
+strip_query_terms off
+
+# access_log /var/log/nginx/squid.log squid
+
+acl all src all
+acl localhost         src         127.0.0.1/32
+acl to_localhost     dst         127.0.0.0/8 0.0.0.0/32
+acl clients          src          192.168.88.0/24
+
+#specify from which network the clients are from (localnet)
+acl localnet src 192.168.88.0/24    # RFC1918 possible internal network
+#on which ports do we allow connections using the proxy
+acl SSL_ports port 443        # https
+# acl SSL_ports port 563        # snews
+# acl SSL_ports port 873        # rsync
+acl Safe_ports port 80        # http
+acl Safe_ports port 3120  # proxy
+acl Safe_ports port 3128        # ftp
+acl Safe_ports port 443        # https
+acl purge method PURGE
+acl CONNECT method CONNECT
+
+external_acl_type checkwhitelist children=20 %METHOD %PROTO %DST %PATH /var/goddard/acl.py
+
+acl opera_match url_regex "opera"
+acl urlmatch url_regex "/var/goddard/urls"
+# acl whitelist dstdomain "/var/goddard/whitelist"
+acl whitelist external checkwhitelist
+
+# Deny requests to unknown ports
+http_access deny !Safe_ports
+# http_access allow opera_match
+http_access deny !whitelist
+# http_access allow urlmatch
+
+# Deny CONNECT to other than SSL ports
+http_access deny CONNECT !SSL_ports
+
+http_access allow all
+http_access deny to_localhost
+http_access allow localnet
+
+# And deny all other access to this proxy
+http_access deny all
+
+error_directory /etc/squid3/errors/
+
+#allow HTTP connections from clients group of IP addresses
+# http_access allow all
+http_reply_access allow all
+icp_access allow all
+
+# Memory
+cache_mem 128 MB
+minimum_object_size 0 bytes
+maximum_object_size 700 MB
+maximum_object_size_in_memory 32 KB
+
+
+##
+refresh_pattern -i \.htm 120 50% 10080 reload-into-ims
+refresh_pattern -i \.html 120 50% 10080 reload-into-ims
+refresh_pattern ^http://*.yahoo.*/.* 720 100% 4320
+refresh_pattern ^http://*.gmail.*/.* 720 100% 4320
+refresh_pattern ^http://*.google.*/.* 720 100% 4320
+refresh_pattern ^http://*.googlesyndication.*/.* 720 100% 4320
+##
+
+#images facebook
+refresh_pattern ((facebook.com)|(85.131.151.39)).*\.(jpg|png|gif)      10800 80% 10800 ignore-reload  override-expire ignore-no-cache
+refresh_pattern -i \.fbcdn.net.*\.(jpg|gif|png|swf|mp3)                  10800 80% 10800 ignore-reload  override-expire ignore-no-cache
+refresh_pattern  static\.ak\.fbcdn\.net*\.(jpg|gif|png)                  10800 80% 10800 ignore-reload  override-expire ignore-no-cache
+refresh_pattern ^http:\/\/profile\.ak\.fbcdn.net*\.(jpg|gif|png)      10800 80% 10800 ignore-reload  override-expire ignore-no-cache
+
+refresh_pattern -i \.(iso|avi|wav|mp3|mp4|mpeg|swf|flv|x-flv)$ 43200 90% 432000 override-expire ignore-no-cache ignore-no-store ignore-private
+refresh_pattern -i \.(deb|rpm|exe|zip|tar|tgz|ram|rar|bin|ppt|doc|tiff)$ 10080 90% 43200 override-expire ignore-no-cache ignore-no-store ignore-private
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .               0       20%     4320
+
+
+client_persistent_connections off
+server_persistent_connections on
+half_closed_clients off
+strip_query_terms off
+quick_abort_min 0 KB
+quick_abort_max 0 KB
+quick_abort_pct 100
+vary_ignore_expire on
+reload_into_ims on
+pipeline_prefetch on
+read_timeout 30 minutes
+client_lifetime 6 hours
+negative_ttl 30 seconds
+positive_dns_ttl 6 hours
+negative_dns_ttl 60 seconds
+pconn_timeout 15 seconds
+request_timeout 1 minute
+store_avg_object_size 13 KB
+log_icp_queries off
+ipcache_size 16384
+ipcache_low 98
+ipcache_high 99
+fqdncache_size 16384
+memory_pools off
+forwarded_for on
+client_db off
+max_filedescriptors 8192


### PR DESCRIPTION
Don't merge just yet. Just a placeholder while I write out the setup files and to get some early feedback from everyone.

This PR will keep updating as I add the sections needed to install this.

@jonathanendersby ^ config files, see files changed.

TODO:
- [x] Setup SQUID config (used a few tricks from Bruce's config too)
- [x] Test Config locally and check that it works
- [x] Create setup script to set up SQUID
- [x] Update ACL script to read actual whitelist into array that it checks (static for now)
- [x] Create script or process that will write the whitelist to file that can be read by the ACL script as well as the captive for debugging on the status page. (Ended up just reading from /var/goddard/node.json)
- [x] Figure out how to get password in bash to apply new walled garden settings
- [x] Update proxy setup script to setup Mikrotik settings
- [x] Update proxy setup to setup Mikrotik walled garden for Squid
- [x] Look into how we are going to handle "opera mini", "Opera Mobile" works already. Mini is going to need some work around's as it just posts everything to a single url. Looking at maybe looking at the content, but we control that page. Worse case we can show a message specifically telling them to disable "TURBO".
- [x] Get SSL working through the Proxy, Mikrotik seems to be doing something that I can't quite pin down.
- [x] Do a full local run with a clean install for testing
